### PR TITLE
refactor:  rename route parameters to cacheKey

### DIFF
--- a/libs/isr/models/src/cache-handler.ts
+++ b/libs/isr/models/src/cache-handler.ts
@@ -30,17 +30,17 @@ export interface VariantRebuildItem {
 
 export abstract class CacheHandler {
   abstract add(
-    url: string,
+    cacheKey: string,
     // it will be buffer when we use compressHtml
     html: string | Buffer,
     config?: CacheISRConfig,
   ): Promise<void>;
 
-  abstract get(url: string): Promise<CacheData>;
+  abstract get(cacheKey: string): Promise<CacheData>;
 
-  abstract has(url: string): Promise<boolean>;
+  abstract has(cacheKey: string): Promise<boolean>;
 
-  abstract delete(url: string): Promise<boolean>;
+  abstract delete(cacheKey: string): Promise<boolean>;
 
   abstract getAll(): Promise<string[]>;
 

--- a/libs/isr/server/src/cache-handlers/filesystem-cache-handler.spec.ts
+++ b/libs/isr/server/src/cache-handlers/filesystem-cache-handler.spec.ts
@@ -1,35 +1,35 @@
 import {
-  convertFileNameToRoute,
-  convertRouteToFileName,
+  convertCacheKeyToFileName,
+  convertFileNameToCacheKey,
 } from './filesystem-cache-handler';
 
 // Use the functions as needed
 describe('Route and File Name Conversion', () => {
-  describe('convertRouteToFileName', () => {
+  describe('convertCacheKeyToFileName', () => {
     it('should convert a simple route without query parameters', () => {
-      const route = '/users/profile';
+      const cacheKey = '/users/profile';
       const expectedFileName = '__users__profile';
-      expect(convertRouteToFileName(route)).toEqual(expectedFileName);
+      expect(convertCacheKeyToFileName(cacheKey)).toEqual(expectedFileName);
     });
 
     it('should convert a route with query parameters', () => {
       const route = '/search?query=test';
       const expectedFileName = '__search++query=test';
-      expect(convertRouteToFileName(route)).toEqual(expectedFileName);
+      expect(convertCacheKeyToFileName(route)).toEqual(expectedFileName);
     });
   });
 
-  describe('convertFileNameToRoute', () => {
+  describe('convertFileNameToCacheKey', () => {
     it('should convert a simple file name back to a route', () => {
       const fileName = '__users__profile';
       const expectedRoute = '/users/profile';
-      expect(convertFileNameToRoute(fileName)).toEqual(expectedRoute);
+      expect(convertFileNameToCacheKey(fileName)).toEqual(expectedRoute);
     });
 
     it('should convert a file name with "++" back to a route with a query parameter', () => {
       const fileName = '__search++query=test';
       const expectedRoute = '/search?query=test';
-      expect(convertFileNameToRoute(fileName)).toEqual(expectedRoute);
+      expect(convertFileNameToCacheKey(fileName)).toEqual(expectedRoute);
     });
   });
 });

--- a/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
@@ -43,7 +43,7 @@ export class FileSystemCacheHandler extends CacheHandler {
   }
 
   async add(
-    route: string,
+    cacheKey: string,
     html: string | Buffer,
     config?: CacheISRConfig,
   ): Promise<void> {
@@ -52,13 +52,13 @@ export class FileSystemCacheHandler extends CacheHandler {
 
       // convert route to file name (replace / with __)
       // ex. /details/user/1 => /details__user__1.html
-      const fileName = convertRouteToFileName(route) + '.html';
+      const fileName = convertCacheKeyToFileName(cacheKey) + '.html';
       const filePath = getFileFullPath(fileName, this.cacheFolderPath);
 
       fs.writeFile(filePath, html, 'utf-8', (err) => {
         if (err) reject('Error: 💥 The request was not cached!');
 
-        this.cache.set(route, {
+        this.cache.set(cacheKey, {
           htmlFilePath: filePath,
           options: config || { revalidate: null },
           createdAt: Date.now(),
@@ -70,26 +70,26 @@ export class FileSystemCacheHandler extends CacheHandler {
     });
   }
 
-  get(route: string): Promise<CacheData> {
+  get(cacheKey: string): Promise<CacheData> {
     return new Promise((resolve, reject) => {
       // ex: route is like: / or /details/user/1
       // cachedUrl is like: { html: 'full-path-to-cache/__filename.html', options: { revalidate: 60 } }
-      const cachedRoute = this.cache.get(route);
+      const cachedMeta = this.cache.get(cacheKey);
 
-      if (cachedRoute) {
+      if (cachedMeta) {
         // on html field we have saved path to file
-        this.readFromFile(cachedRoute.htmlFilePath, cachedRoute.isBuffer)
+        this.readFromFile(cachedMeta.htmlFilePath, cachedMeta.isBuffer)
           .then((html) => {
             const cacheData: CacheData = {
               html,
-              options: cachedRoute.options,
-              createdAt: cachedRoute.createdAt,
+              options: cachedMeta.options,
+              createdAt: cachedMeta.createdAt,
             };
             resolve(cacheData);
           })
           .catch((err) => {
             reject(
-              `Error: 💥 Cannot read cache file for route ${route}: ${cachedRoute.htmlFilePath}, ${err}`,
+              `Error: 💥 Cannot read cache file for cacheKey ${cacheKey}: ${cachedMeta.htmlFilePath}, ${err}`,
             );
           });
       } else {
@@ -98,29 +98,29 @@ export class FileSystemCacheHandler extends CacheHandler {
     });
   }
 
-  has(route: string): Promise<boolean> {
-    return Promise.resolve(this.cache.has(route));
+  has(cacheKey: string): Promise<boolean> {
+    return Promise.resolve(this.cache.has(cacheKey));
   }
 
-  delete(route: string): Promise<boolean> {
+  delete(cacheKey: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      const cacheData = this.cache.get(route);
+      const cachedMeta = this.cache.get(cacheKey);
 
-      if (cacheData) {
-        fs.unlink(cacheData.htmlFilePath, (err) => {
+      if (cachedMeta) {
+        fs.unlink(cachedMeta.htmlFilePath, (err) => {
           if (err) {
             reject(
-              'Error: 💥 Cannot delete cache file for route ' +
-                route +
-                `: ${cacheData.htmlFilePath}`,
+              'Error: 💥 Cannot delete cache file for cacheKey ' +
+                cacheKey +
+                `: ${cachedMeta.htmlFilePath}`,
             );
           } else {
-            this.cache.delete(route);
+            this.cache.delete(cacheKey);
             resolve(true);
           }
         });
       } else {
-        reject(`Error: 💥 Route: ${route} is not cached.`);
+        reject(`Error: 💥 cacheKey: ${cacheKey} is not cached.`);
       }
     });
   }
@@ -172,19 +172,19 @@ export class FileSystemCacheHandler extends CacheHandler {
       const filePath = join(this.cacheFolderPath, file);
 
       const fileName = file.replace('.html', ''); // remove .html extension
-      const route = convertFileNameToRoute(fileName);
+      const cacheKey = convertFileNameToCacheKey(fileName);
 
       const html = fs.readFileSync(filePath, 'utf-8');
       const { revalidate, errors } = getRouteISRDataFromHTML(html);
 
-      this.cache.set(route, {
+      this.cache.set(cacheKey, {
         htmlFilePath: filePath, // full path to file
         options: { revalidate, errors },
         createdAt: Date.now(),
         isBuffer: false,
       });
 
-      console.log('The request was stored in cache! Route: ', route);
+      console.log('The request was stored in cache! cacheKey: ', cacheKey);
     }
   }
 
@@ -233,16 +233,16 @@ export class FileSystemCacheHandler extends CacheHandler {
         '',
       );
 
-      let route = '';
+      let cacheKey = '';
       if (pathWithoutPrerenderedPagesPath === '/index.html') {
-        route = '/';
+        cacheKey = '/';
       } else {
-        route = pathWithoutPrerenderedPagesPath
+        cacheKey = pathWithoutPrerenderedPagesPath
           .substring(0)
           .replace('/index.html', '');
       }
 
-      const newFileName = convertRouteToFileName(route);
+      const newFileName = convertCacheKeyToFileName(cacheKey);
       const newFilePath =
         getFileFullPath(newFileName, this.cacheFolderPath) + '.html';
 
@@ -345,24 +345,24 @@ function getFileFullPath(fileName: string, cacheFolderPath: string): string {
 }
 
 /**
- * This function takes a string parameter 'route' and replaces all '/' characters in it with '__' and returns the modified string.
+ * This function takes a string parameter 'cacheKey' and replaces all '/' characters in it with '__' and returns the modified string.
  *
  * @internal
- * @param {string} route - The string representing the route to be converted into a file name.
+ * @param {string} cacheKey - The string representing the cacheKey to be converted into a file name.
  * @returns {string} The modified string representing the file name obtained by replacing '/' characters with '__'.
  */
-export function convertRouteToFileName(route: string): string {
-  // replace all occurrences of '/' character in the 'route' string with '__' using regular expression
-  return route
+export function convertCacheKeyToFileName(cacheKey: string): string {
+  // replace all occurrences of '/' character in the 'cacheKey' string with '__' using regular expression
+  return cacheKey
     .replace(new RegExp('/', 'g'), '__')
     .replace(new RegExp('\\?', 'g'), '++');
 }
 
 /**
  * This function takes a string parameter 'fileName' and replaces all '__' strings in it with '/' and returns the modified string.
- * @param fileName - The string representing the file name to be converted into a route.
+ * @param fileName - The string representing the file name to be converted into a cacheKey.
  */
-export function convertFileNameToRoute(fileName: string): string {
+export function convertFileNameToCacheKey(fileName: string): string {
   // replace all occurrences of '__' string in the 'fileName' string with '/' using regular expression
   return fileName
     .replace(new RegExp('\\+\\+', 'g'), '?')

--- a/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
@@ -222,7 +222,9 @@ export class FileSystemCacheHandler extends CacheHandler {
         }
       }
     } catch (err) {
-      console.error('ERROR! 💥 ! Cannot read folder: ' + folderPath);
+      console.error(
+        `ERROR! 💥 ! Cannot read folder: ${folderPath}, err: ${err.message}`,
+      );
     }
 
     for (const { path } of pathsToCache) {
@@ -316,7 +318,7 @@ function findIndexHtmlFilesRecursively(
     });
   } catch (err) {
     // If an error occurs, log an error message and return an empty array
-    console.error('ERROR! 💥 ! Cannot read folder: ' + path);
+    console.error(`ERROR! 💥 ! Cannot read folder: ${path}, ${err.message}`);
     return [];
   }
 

--- a/libs/isr/server/src/cache-handlers/in-memory-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/in-memory-cache-handler.ts
@@ -16,7 +16,7 @@ export class InMemoryCacheHandler extends CacheHandler {
   }
 
   add(
-    url: string,
+    cacheKey: string,
     html: string | Buffer,
     config: CacheISRConfig = defaultCacheISRConfig,
   ): Promise<void> {
@@ -26,15 +26,15 @@ export class InMemoryCacheHandler extends CacheHandler {
         options: config,
         createdAt: Date.now(),
       };
-      this.cache.set(url, cacheData);
+      this.cache.set(cacheKey, cacheData);
       resolve();
     });
   }
 
-  get(url: string): Promise<CacheData> {
+  get(cacheKey: string): Promise<CacheData> {
     return new Promise((resolve, reject) => {
-      if (this.cache.has(url)) {
-        resolve(this.cache.get(url) as CacheData);
+      if (this.cache.has(cacheKey)) {
+        resolve(this.cache.get(cacheKey) as CacheData);
       }
       reject('This url does not exist in cache!');
     });
@@ -46,15 +46,15 @@ export class InMemoryCacheHandler extends CacheHandler {
     });
   }
 
-  has(url: string): Promise<boolean> {
+  has(cacheKey: string): Promise<boolean> {
     return new Promise((resolve) => {
-      resolve(this.cache.has(url));
+      resolve(this.cache.has(cacheKey));
     });
   }
 
-  delete(url: string): Promise<boolean> {
+  delete(cacheKey: string): Promise<boolean> {
     return new Promise((resolve) => {
-      resolve(this.cache.delete(url));
+      resolve(this.cache.delete(cacheKey));
     });
   }
 

--- a/libs/isr/server/src/utils/timeout.ts
+++ b/libs/isr/server/src/utils/timeout.ts
@@ -12,6 +12,8 @@ export async function executeWithTimeout<T>(
   try {
     return (await Promise.race([promise, timeoutPromise])) as T;
   } finally {
-    timeoutId && clearTimeout(timeoutId); // Clear the timeout once the operation is done or fails
+    if (timeoutId) {
+      clearTimeout(timeoutId); // Clear the timeout once the operation is done or fails
+    }
   }
 }


### PR DESCRIPTION
Address linting errors and improve code clarity by renaming route parameters to cacheKey across relevant files.